### PR TITLE
Safer conversion with setting checks.

### DIFF
--- a/lang/en/block_simple_restore.php
+++ b/lang/en/block_simple_restore.php
@@ -9,6 +9,7 @@ $string['no_context'] = 'Empty context: A restore object must be given a context
 $string['no_file'] = 'Empty file: A restore object must be given a file.';
 $string['no_filter'] = 'Enter a valid course shortname.';
 $string['no_arguments'] = $string['pluginname'] . ' error: Invalid arguments were passed to prep restore.';
+$string['no_restore'] = 'The restore was unable to complete due to the following error: {$a}';
 $string['empty_backups'] = 'No course backups found.';
 
 $string['backup_name'] = 'Backup name / ';

--- a/lib.php
+++ b/lib.php
@@ -242,7 +242,7 @@ class simple_restore {
                 }
                 // Set admin value
                 // Some settings may be locked by permission
-                if ($setting->get_status() != base_setting::LOCKED_BY_PERMISSION) {
+                if ($setting->get_status() == base_setting::NOT_LOCKED) {
                     $setting->set_value($admin_setting);
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -241,7 +241,10 @@ class simple_restore {
                     continue;
                 }
                 // Set admin value
-                $setting->set_value($admin_setting);
+                // Some settings may be locked by permission
+                if ($setting->get_status() != base_setting::LOCKED_BY_PERMISSION) {
+                    $setting->set_value($admin_setting);
+                }
             }
         }
 

--- a/restore.php
+++ b/restore.php
@@ -34,11 +34,17 @@ $header = $course->fullname;
 
 // This conditional returns html content for the ajax reponse
 if($confirm and data_submitted()) {
-    $restore->execute();
+    try {
+        $restore->execute();
 
-    echo $OUTPUT->notification(
-        get_string('restoreexecutionsuccess', 'backup'), 'notifysuccess'
-    );
+        echo $OUTPUT->notification(
+            get_string('restoreexecutionsuccess', 'backup'), 'notifysuccess'
+        );
+    } catch (Exception $e) {
+        $a = $e->getMessage();
+        echo $OUTPUT->notification(simple_restore_utils::_s('no_restore', $a));
+    }
+
     echo $OUTPUT->continue_button(
         new moodle_url('/course/view.php', array('id' => $course->id))
     );


### PR DESCRIPTION
Teachers were able to restore from backadel backups OK. The student data thing might be a separate issue.

@adamzap, can you review the code when you have a chance.
@rrusso, can you verify that a non-student data archive works?

In the meantime I'll start testing student data.
